### PR TITLE
Remove logo

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -13,7 +13,6 @@ const AppHeader: React.FC<AppHeaderProps> = () => {
 
   return (
     <header className="flex w-full  items-center justify-between bg-brand-background dark:bg-brand-darkBackground p-[15px] md:p-[50px] dark:text-white">
-      <!-- <Link to="/">(Insert customer logo)</Link> -->
       <nav className="flex space-x-[20px] md:space-x-[40px] items-center ">
         <AccessibilityPopup isOpen={modal} onClose={() => setModal(false)} />
         <a href="#">


### PR DESCRIPTION
We don't need and want this for the ACB and NFB conferences. These are blind or partially blind people, they don't care about the logo section. 

It was, however, confusing them, because it was representing itself as something they should care about. When we get back from the conference, we can work on improving this element and re-introduce it.